### PR TITLE
Wrong version 53 package-info

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -265,6 +265,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <release>9</release>
+                    <createMissingPackageInfoClass>false</createMissingPackageInfoClass>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
                         <arg>-Xdoclint:all</arg>
@@ -281,6 +282,7 @@
                         </goals>
                         <configuration>
                             <release>8</release>
+                            <createMissingPackageInfoClass>true</createMissingPackageInfoClass>
                             <excludes>
                                 <exclude>module-info.java</exclude>
                             </excludes>


### PR DESCRIPTION
Original issue is here: https://github.com/eclipse-ee4j/parsson/issues/73
PR for Parsson is: https://github.com/eclipse-ee4j/parsson/pull/74

Fix can be verified in this way:
```
jsonp/api$ javap -verbose -classpath target/jakarta.json-api-2.1.1-SNAPSHOT.jar jakarta.json.package-info | grep version
  minor version: 0
  major version: 52
```
