### PR TITLE
Fix typo in Java Doc

### DIFF
--- a/api/src/main/java/jakarta/json/Json.java
+++ b/api/src/main/java/jakarta/json/Json.java
@@ -255,7 +255,7 @@ public final class Json {
 
     /**
      * Creates a JSON array builder, initialized with the content of specified {@code collection}.
-     * If the @{code collection} contains {@link Optional}s then resulting JSON array builder
+     * If the {@code collection} contains {@link Optional}s then resulting JSON array builder
      * contains the value from the {@code collection} only if the {@link Optional} is not empty.
      *
      * @param collection the initial data for the builder

--- a/api/src/main/java/jakarta/json/Json.java
+++ b/api/src/main/java/jakarta/json/Json.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at


### PR DESCRIPTION
Changed a small typo in the Java Docs in `Json.java`.